### PR TITLE
Update JSONPathMatcher.cs to cover the string path selection to a child

### DIFF
--- a/src/WireMock.Net/Matchers/JSONPathMatcher.cs
+++ b/src/WireMock.Net/Matchers/JSONPathMatcher.cs
@@ -123,7 +123,12 @@ public class JsonPathMatcher : IStringMatcher, IObjectMatcher
     {
         var array = ConvertJTokenToJArrayIfNeeded(jToken);
 
-        return MatchScores.ToScore(_patterns.Select(pattern => array.SelectToken(pattern.GetPattern())?.Any() == true).ToArray(), MatchOperator);
+        // The SelectToken method can accept string path to a child token ( i.e. “Manufacturers[0].Products[0].Price”) in that cat it will return a JValue(some type) which not implement the IEnumerable interface.
+        // Using ?.Any() == true relays that we use a JSONPath queries and the SelectToken will return a JObject ( implements the IEnumerable interface).
+        // So the current code works only when the JSONPath is expression and not when we pass a valid string path to child. 
+        // My suggestion is to roll back to != null to cover the both cases.
+ 
+        return MatchScores.ToScore(_patterns.Select(pattern => array.SelectToken(pattern.GetPattern()) != null ).ToArray(), MatchOperator);
     }
 
     // https://github.com/WireMock-Net/WireMock.Net/issues/965


### PR DESCRIPTION
The .SelectToken method accept string path selection and JSONPath queries. The current code works only for the queries because the result is JObject. When the string path is selected the result is JValue and event with a valid result the code the code doesn't return valued result. https://www.newtonsoft.com/json/help/html/SelectToken.htm